### PR TITLE
Add <-json and ->json convenience functions

### DIFF
--- a/src/jason/convenience.clj
+++ b/src/jason/convenience.clj
@@ -14,6 +14,12 @@
   ->db-json
   <-db-json)
 
+(let [coders (jason/new-json-coders
+               {:decode-key-fn (jason/->decode-key-fn keyword)
+                :pretty        true})]
+  (def <-json (:<-json coders))
+  (def ->json (:->json coders)))
+
 (defcoders wire
   :encode-key-fn (jason/->encode-key-fn ->camelCaseString)
   :decode-key-fn (jason/->decode-key-fn ->kebab-case-keyword)

--- a/test/jason/convenience_test.clj
+++ b/test/jason/convenience_test.clj
@@ -6,6 +6,45 @@
 
    [jason.convenience :as convenience]))
 
+(deftest ->json
+  (testing "returns nil when nil provided"
+    (is (nil? (convenience/->json nil))))
+
+  (testing "returns a json string"
+    (is (= (multiline-str
+             "{"
+             "  \"key\" : 123"
+             "}")
+          (convenience/->json {:key 123}))))
+
+  (testing "keeps keys as they are"
+    (is (= (multiline-str
+             "{"
+             "  \"foo-key\" : 123,"
+             "  \"bar_key\" : 123,"
+             "  \"bazKey\" : 123"
+             "}")
+          (convenience/->json {:foo-key 123
+                               :bar_key 123
+                               :bazKey 123})))))
+
+(deftest <-json
+  (testing "returns nil when nil provided"
+    (is (nil? (convenience/<-json nil))))
+
+  (testing "returns nil when empty string provided"
+    (is (nil? (convenience/<-json ""))))
+
+  (testing "parses json"
+    (is (= {:key 123}
+          (convenience/<-json "{\"key\": 123}"))))
+
+  (testing "leaves keys as they are"
+    (is (= {:foo-key 123
+            :bar_key 123
+            :bazKey 123}
+          (convenience/<-json "{\"foo-key\": 123, \"bar_key\": 123, \"bazKey\": 123}")))))
+
 (deftest ->wire-json
   (testing "returns nil when nil provided"
     (is (nil? (convenience/->wire-json nil))))


### PR DESCRIPTION
`<-json` and `->json` decode and encode respectively while keeping casing the same as in the original source.
